### PR TITLE
SUPPORT-67097: change colours for text spans in stories source code

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -109,6 +109,10 @@ hr {
 pre {
   overflow: auto;
 }
+pre span,
+pre span.token.plain-text {
+  color: whitesmoke;
+}
 code,
 kbd,
 pre,


### PR DESCRIPTION
Change colours for text spans in stories source code.
Before changes example:

<img width="1004" alt="Screenshot 2023-01-23 at 09 41 24" src="https://user-images.githubusercontent.com/97681876/213997275-7f8e1521-8c73-4697-a463-006b99d71ff4.png">
<img width="1004" alt="Screenshot 2023-01-23 at 09 41 38" src="https://user-images.githubusercontent.com/97681876/213997303-8c713a96-0f86-4a5f-96c3-a1a0d6575aad.png">

After changes example:

<img width="1004" alt="Screenshot 2023-01-23 at 09 44 01" src="https://user-images.githubusercontent.com/97681876/213997571-cf68c9b2-4609-4977-b1b6-4de68afe7e77.png">
<img width="1004" alt="Screenshot 2023-01-23 at 09 44 48" src="https://user-images.githubusercontent.com/97681876/213997668-65ae600f-b697-44ae-ac64-ebea3df9c69f.png">